### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ This Pyramid add-on defines an encrypting, pickle-based cookie serializer,
 using ``PyNaCl`` [1] to generate the symmetric encryption for the cookie state.
 
 
-[1] http://pynacl.readthedocs.org/en/latest/secret/
+[1] https://pynacl.readthedocs.io/en/latest/secret/
 
 See:  ``docs/index.rst`` for the documentation.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,7 +5,7 @@ This Pyramid add-on defines an encrypting, pickle-based cookie serializer,
 using ``PyNaCl`` [1] to generate the symmetric encryption for the cookie state.
 
 
-[1] http://pynacl.readthedocs.org/en/latest/secret/
+[1] https://pynacl.readthedocs.io/en/latest/secret/
 
 Contents:
 


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
