### PR TITLE
Pass samesite option through to BaseCookieSessionFactory

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -47,7 +47,7 @@ License Terms
 -------------
 
 Code committed to the Repoze Project source repository (Committed Code) must
-be governed by the Repoze Public License (http://repoze.org/LICENSE.txt, aka
+be governed by the Repoze Public License (LICENSE.txt, aka
 "the RPL") or another license acceptable to Agendaless Consulting.  Until
 Agendaless Consulting declares in writing an acceptable license other than
 the RPL, only the RPL shall be used.  A list of exceptions is detailed within
@@ -94,7 +94,7 @@ List of Contributors
 ====================
 
 The below-signed are contributors to a code repository that is part of the
-project named "repoze.tm2".
+project named "pyramid_nacl_session".
 
 Each below-signed contributor has read, understand and agrees to the terms
 above in the section within this document entitled "Repoze Project Contributor
@@ -110,3 +110,5 @@ Contributors
 - Julien Cigar, 2019/12/13
 
 - Bert JW Regeer, 2020/05/04
+
+- Nathan Merritt, 2020/06/16

--- a/src/pyramid_nacl_session/session.py
+++ b/src/pyramid_nacl_session/session.py
@@ -18,6 +18,7 @@ def EncryptedCookieSessionFactory(
     reissue_time=0,
     set_on_exception=True,
     serializer=None,
+    samesite='Lax',
 ):
     """
     Configure a :term:`session factory` which will provide encrypted
@@ -57,6 +58,10 @@ def EncryptedCookieSessionFactory(
     ``httponly``
       Hide the cookie from Javascript by setting the 'HttpOnly' flag of the
       session cookie. Default: ``False``.
+
+    ``samesite``
+      The 'samesite' option of the session cookie. Set the value to ``None``
+      to turn off the samesite option.  Default: ``'Lax'``.
 
     ``timeout``
       A number of seconds of inactivity before a session times out. If
@@ -107,4 +112,5 @@ def EncryptedCookieSessionFactory(
         timeout=timeout,
         reissue_time=reissue_time,
         set_on_exception=set_on_exception,
+        samesite=samesite,
     )

--- a/src/pyramid_nacl_session/session.py
+++ b/src/pyramid_nacl_session/session.py
@@ -18,7 +18,7 @@ def EncryptedCookieSessionFactory(
     reissue_time=0,
     set_on_exception=True,
     serializer=None,
-    samesite='Lax',
+    samesite="Lax",
 ):
     """
     Configure a :term:`session factory` which will provide encrypted

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -31,6 +31,7 @@ class TestEncryptedCookieSessionFactory(unittest.TestCase):
             {"pynacl.session.secure": "true", "session.httponly": "true"}
         )
         test_cookie_name = self._build_cookie({"session.cookie_name": "_test_"})
+        test_samesite = self._build_cookie({"session.samesite": "Strict"})
 
         _session_data = {
             "k1": "v1",
@@ -47,6 +48,8 @@ class TestEncryptedCookieSessionFactory(unittest.TestCase):
         self.assertIn("HttpOnly;", test_http_secure)
         self.assertIn("secure;", test_http_secure)
         self.assertIn("_test_=", test_cookie_name)
+        self.assertIn("SameSite=Lax", test_cookie_name)
+        self.assertIn("SameSite=Strict", test_samesite)
 
         with self.assertRaises(ValueError):
             self._build_cookie({"session.secret": "invalid"})


### PR DESCRIPTION
This makes it possible to do `EncryptedCookieSessionFactory(..., samesite='None')` and future-proof cross-domain session cookies