### PR TITLE
follow Pyramid 2.0 and make JSONSerializer the default

### DIFF
--- a/src/pyramid_nacl_session/serializer.py
+++ b/src/pyramid_nacl_session/serializer.py
@@ -5,7 +5,7 @@ import binascii
 from nacl.exceptions import CryptoError
 from nacl.secret import SecretBox
 from nacl.utils import random
-from pyramid.session import PickleSerializer
+from pyramid.session import JSONSerializer
 
 
 class EncryptedSerializer(object):
@@ -19,7 +19,7 @@ class EncryptedSerializer(object):
         method should accept bytes and return a Python object. The ``dumps``
         method should accept a Python object and return bytes. A ``ValueError``
         should be raised for malformed inputs. Default: ``None``, which will
-        use :class:`pyramid.session.PickleSerializer`.
+        use :class:`pyramid.session.JSONSerializer`.
     """
 
     def __init__(self, secret, serializer=None):
@@ -32,7 +32,7 @@ class EncryptedSerializer(object):
         self.box = SecretBox(secret)
 
         if serializer is None:
-            serializer = PickleSerializer()
+            serializer = JSONSerializer()
 
         self.serializer = serializer
 

--- a/src/pyramid_nacl_session/session.py
+++ b/src/pyramid_nacl_session/session.py
@@ -99,7 +99,10 @@ def EncryptedCookieSessionFactory(
     if serializer is None:
         serializer = PickleSerializer()
 
-    encrypted_serializer = EncryptedSerializer(secret, serializer=serializer,)
+    encrypted_serializer = EncryptedSerializer(
+        secret,
+        serializer=serializer,
+    )
 
     return BaseCookieSessionFactory(
         encrypted_serializer,


### PR DESCRIPTION
This matches the Pyramid 2.0 release's default, as described here: https://docs.pylonsproject.org/projects/pyramid/en/latest/whatsnew-2.0.html

Also has the added benefit of silencing these warnings: 

```
  /Users/nathan/.pyenv/versions/3.9.9/envs/venv/lib/python3.9/site-packages/pyramid_nacl_session/serializer.py:8: DeprecationWarning: PickleSerializer: pyramid.session.PickleSerializer is deprecated as of Pyramid 2.0 for security concerns. Use pyramid.session.JSONSerializer or reference the narrative documentation for information on building a migration tool.
    from pyramid.session import PickleSerializer
```